### PR TITLE
Feature: please dont write any more logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # OpenVPN for Docker
 
-**the original project - [jpetazzo/dockvpn](https://github.com/jpetazzo/dockvpn)** and it has its own [automatic build on dockerhub](https://hub.docker.com/r/jpetazzo/dockvpn/). 
+**the original project - [jpetazzo/dockvpn](https://github.com/jpetazzo/dockvpn)** and it has its own [automatic build on dockerhub](https://hub.docker.com/r/jpetazzo/dockvpn/).
 
- 
+
 Quick instructions:
 
 ```bash
-CID=$(docker run -d --privileged -p 1194:1194/udp -p 443:443/tcp umputun/dockvpn)
-docker run -t -i -p 8080:8080 --volumes-from $CID umputun/dockvpn serveconfig
+CID=$(docker run -d --privileged -p 1194:1194/udp -p 443:443/tcp -e "NO_LOGS_PLEASE=1" --log-driver none umputun/dockvpn)
+docker run -t -i -p 8080:8080 -e "NO_LOGS_PLEASE=1" --log-driver none --volumes-from $CID umputun/dockvpn serveconfig
+```
+
+Download file with `curl`:
+```bash
+curl -k https://[SERVER_IP]:8080/ > ~/openvpn.ovpn
 ```
 
 Now download the file located at the indicated URL. You will get a

--- a/README.md
+++ b/README.md
@@ -6,8 +6,15 @@
 Quick instructions:
 
 ```bash
-CID=$(docker run -d --privileged -p 1194:1194/udp -p 443:443/tcp -e "NO_LOGS_PLEASE=1" --log-driver none umputun/dockvpn)
-docker run -t -i -p 8080:8080 -e "NO_LOGS_PLEASE=1" --log-driver none --volumes-from $CID umputun/dockvpn serveconfig
+CID=$(docker run -d --privileged -p 1194:1194/udp -p 443:443/tcp umputun/dockvpn)
+docker run -t -i -p 8080:8080 --volumes-from $CID umputun/dockvpn serveconfig
+```
+
+Or run without logs:
+
+```bash
+CID=$(docker run -d --privileged -p 1194:1194/udp -p 443:443/tcp -e "DISABLE_LOGS=1" --log-driver none umputun/dockvpn)
+docker run -t -i -p 8080:8080 -e "DISABLE_LOGS=1" --log-driver none --volumes-from $CID umputun/dockvpn serveconfig
 ```
 
 Download file with `curl`:

--- a/bin/run
+++ b/bin/run
@@ -105,6 +105,15 @@ EOF
 iptables -t nat -A POSTROUTING -s 192.168.255.0/24 -o eth0 -j MASQUERADE
 
 touch tcp443.log udp1194.log http8080.log
-while true ; do openvpn tcp443.conf ; done >> tcp443.log &
-while true ; do openvpn udp1194.conf ; done >> udp1194.log &
+
+LOGFILE_TCP=tcp443.log
+LOGFILE_UDP=udp1194.log
+[ -z "$NO_LOGS_PLEASE" ] || {
+    LOGFILE_TCP=/dev/null
+    LOGFILE_UDP=/dev/null
+}
+
+while true ; do openvpn tcp443.conf ; done >> "$LOGFILE_TCP" &
+while true ; do openvpn udp1194.conf ; done >> "$LOGFILE_UDP" &
+
 tail -F *.log

--- a/bin/run
+++ b/bin/run
@@ -111,7 +111,7 @@ touch tcp443.log udp1194.log http8080.log
 
 LOGFILE_TCP=tcp443.log
 LOGFILE_UDP=udp1194.log
-[ -z "$NO_LOGS_PLEASE" ] || {
+[ -z "$DISABLE_LOGS" ] || {
     LOGFILE_TCP=/dev/null
     LOGFILE_UDP=/dev/null
 }

--- a/bin/serveconfig
+++ b/bin/serveconfig
@@ -13,7 +13,7 @@ while ! [ -f client.http ]; do
 done
 
 LOGFILE_HTTP=http8080.log
-[ -z "$NO_LOGS_PLEASE" ] || {
+[ -z "$DISABLE_LOGS" ] || {
     LOGFILE_HTTP=/dev/null
 }
 

--- a/bin/serveconfig
+++ b/bin/serveconfig
@@ -12,8 +12,13 @@ while ! [ -f client.http ]; do
     sleep 3
 done
 
+LOGFILE_HTTP=http8080.log
+[ -z "$NO_LOGS_PLEASE" ] || {
+    LOGFILE_HTTP=/dev/null
+}
+
 echo "https://$(curl -s http://myip.enix.org/REMOTE_ADDR):8080/"
 socat -d -d \
     OPENSSL-LISTEN:8080,fork,reuseaddr,key=key.pem,certificate=cert.pem,verify=0 \
     EXEC:'cat client.http' \
-    2>> http8080.log
+    2>> "$LOGFILE_HTTP"


### PR DESCRIPTION
Использую данный контейнер на VPS с маленьким диском и устал периодически ходить и чистить логи, которые забивают диск до предела. Да и не секурно писать в логи все места где я ходил, да откуда было подключение. Поэтому допилил проект настройкой, которая убирает логирование в файлы. 

Для отключения логов - необходимо добавить env-переменную ~~`NO_LOGS_PLEASE`~~ `DISABLE_LOGS` с любым значением при запуске контейнеров. Также, нет смысла логировать сам контейнер, поэтому имеет смысл также добавить `--log-driver none`. Всё это я добавил в ридми (возможно, стоило сделать отдельный раздел, но я сделал это всё на скорую руку).

PS: в хроме сейчас из-за самоподписного сертификата не открывает ссылку для скачивания `.ovpn` файла (даже если нажать "Дополнительно"). Поэтому добавил команду для скачивания курлом.

PPS: Лень было писать на английском...