### PR TITLE
feat: explicitly specify cipher method

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -21,6 +21,7 @@ chmod 600 key.pem
 
 [ -f tcp443.conf ] || cat >tcp443.conf <<EOF
 server 192.168.255.0 255.255.255.128
+cipher AES-256-CBC
 verb 3
 duplicate-cn
 key key.pem
@@ -41,6 +42,7 @@ EOF
 
 [ -f udp1194.conf ] || cat >udp1194.conf <<EOF
 server 192.168.255.128 255.255.255.128
+cipher AES-256-CBC
 verb 3
 duplicate-cn
 key key.pem
@@ -68,6 +70,7 @@ MY_IP_ADDR=$(curl -s http://myip.enix.org/REMOTE_ADDR)
 
 [ -f client.ovpn ] || cat >client.ovpn <<EOF
 client
+cipher AES-256-CBC
 nobind
 dev tun
 redirect-gateway def1


### PR DESCRIPTION
Explicitly add `cipher AES-256-CBC` to both client and server configurations.

Existing configuration makes server use `cipher BF-CBC` (because `ubuntu:focal` has openvpn package version 2.4.7-1ubuntu2.20.04.2 as per 2022-02-22).
Starting with openvpn 2.5+ default cipher was changed on `AES-256-CBC`, and `BF-CBC` is not enabled by default. 
As a result if you use a client w/ openvpn 2.5+, it won't be able to connect to a server until the client explicitly re-enables 'old' cipher manually.

Possibly it worth relying on more 'modern' cipher, specifying this explicitly. 
On the other hand, it's debatable - re-defining default value from openvpn package means that basically we now need to keep track of which cipher to use instead of relying on openvpn package