### PR TITLE
Remove dh from client configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 RUN apt-get update -q
 RUN apt-get install -qy openvpn iptables socat curl
 ADD ./bin /usr/local/sbin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:focal
 RUN apt-get update -q
 RUN apt-get install -qy openvpn iptables socat curl
 ADD ./bin /usr/local/sbin

--- a/bin/run
+++ b/bin/run
@@ -84,9 +84,6 @@ redirect-gateway def1
 <ca>
 `cat cert.pem`
 </ca>
-<dh>
-`cat dh.pem`
-</dh>
 
 <connection>
 remote $MY_IP_ADDR 1194 udp


### PR DESCRIPTION
New versions of OpenVPN Connect don't support configs with dh section

```
[Aug 22, 2023, 01:04:02] NOTE: This configuration contains options that were not used:
[Aug 22, 2023, 01:04:02] Server only option
[Aug 22, 2023, 01:04:02] 8 [dh] [-----BEGIN DH PARAMETERS----- MIIBCAKCAQEAl0HXaTKkoKGsSTkGQkvsnp...]
```

https://forums.openvpn.net/viewtopic.php?t=35937